### PR TITLE
Update bot.coffee

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -18,7 +18,7 @@ class SlackBot extends Adapter
   # @param {Object} options.rtmStart - options for `rtm.start` Web API method
   ###
   constructor: (@robot, @options) ->
-    super
+    super()
     @robot.logger.info "hubot-slack adapter v#{pkg.version}"
     @client = new SlackClient @options, @robot
 


### PR DESCRIPTION
###  Summary

```
Hubot@0.0.0 /usr/hubot
`-- hubot@3.3.2
  `-- coffeescript@1.6.3 

npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.1.2 (node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.1.3: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
[Mon Nov 16 2020 20:21:15 GMT+0000 (UTC)] ERROR Cannot load adapter slack - /usr/hubot/node_modules/hubot-slack/src/bot.coffee:21:10: error: unexpected newline
    super
         ^
```
### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).